### PR TITLE
Add components-a?rgb with tests

### DIFF
--- a/src/main/clojure/mikera/image/colours.clj
+++ b/src/main/clojure/mikera/image/colours.clj
@@ -25,14 +25,19 @@
     (long-colour (Colours/getARGBClamped (double a)  (double r) (double g) (double b)))))
 
 (defn components-argb 
-  "Return the ARGB components of a colour value, in a 4-element vector of double values"
+  "Return the ARGB components of a colour value, in a 4-element vector of long values"
   ([^long argb]
-    (TODO)))
+   [(bit-shift-right (bit-and argb 0xFF000000) 24)
+    (bit-shift-right (bit-and argb 0x00FF0000) 16)
+    (bit-shift-right (bit-and argb 0x0000FF00) 8)
+    (bit-and argb 0x000000FF)]))
 
 (defn components-rgb 
-  "Return the RGB components of a colour value, in a 3-element vector of double values"
+  "Return the RGB components of a colour value, in a 3-element vector of long values"
   ([^long argb]
-    (TODO)))
+   [(bit-shift-right (bit-and argb 0x00FF0000) 16)
+    (bit-shift-right (bit-and argb 0x0000FF00) 8)
+    (bit-and argb 0x000000FF)]))
 
 (defn rand-colour
   "Returns a random RGB colour value with 100% alpha"

--- a/src/test/clojure/mikera/image/test_colours.clj
+++ b/src/test/clojure/mikera/image/test_colours.clj
@@ -5,6 +5,12 @@
 (deftest test-rgb
   (is (== 0xFF000000 (rgb 0 0 0))))
 
+(deftest test-components-argb
+  (is (= [0xDE 0xAD 0xBE 0xEF] (components-argb 0xDEADBEEF))))
+
+(deftest test-components-rgb
+  (is (= [0xFE 0xBA 0xBE] (components-rgb 0xCAFEBABE))))
+
 (deftest test-rand-colour
   (let [rc (rand-colour)]
     (is (== 0xFF000000 (bit-and 0xFF000000 rc)))))


### PR DESCRIPTION
Hello,

I wanted to visualize a PRNG this morning and found imagez. It's great!

I noticed that `components-a?rgb` were unimplemented, so I decided to whip up a simple implementation.

The docstring said that the functions would return doubles, but it seems more in keeping with the rest of the library to simply return longs, the return type of bit-ops on long inputs.

Thank you!
