### PR TITLE
Ensure int argb image type

### DIFF
--- a/src/main/clojure/mikera/image/core.clj
+++ b/src/main/clojure/mikera/image/core.clj
@@ -5,6 +5,7 @@
   (:require [mikera.image.filters :as filt])
   (:require [mikera.image.protocols :as protos])
   (:use mikera.cljutils.error) 
+  (:import [java.awt Graphics2D])
   (:import [java.awt.image BufferedImage BufferedImageOp])
   (:import [javax.imageio ImageIO IIOImage ImageWriter ImageWriteParam])
   (:import [org.imgscalr Scalr])
@@ -49,6 +50,17 @@
   (^BufferedImage [^BufferedImage image width-factor height-factor]
     (resize image (* (.getWidth image) width-factor) (* (.getHeight image) height-factor))))
 
+(defn ensure-default-image-type
+  "If the provided image is does not have the default image type
+  (BufferedImage/TYPE_INT_ARGB) a copy with that type is returned."
+  (^BufferedImage [^BufferedImage image]
+    (if (= BufferedImage/TYPE_INT_ARGB (.getType image))
+      image
+      (let [copy (new-image (.getWidth image) (.getHeight image))
+            ^Graphics2D g (.getGraphics copy)]
+        (.drawImage g image nil 0 0)
+        copy))))
+
 (defn load-image
   "Loads a BufferedImage from a string, file or a URL representing a resource
   on the classpath.
@@ -58,7 +70,7 @@
     (load-image \"/some/path/to/image.png\")
     ;; (require [clojure.java.io :refer [resource]])
     (load-image (resource \"some/path/to/image.png\"))"
-  (^BufferedImage [resource] (protos/as-image resource)))
+  (^BufferedImage [resource] (ensure-default-image-type (protos/as-image resource))))
 
 (defn load-image-resource
   "Loads an image from a named resource on the classpath.

--- a/src/main/clojure/mikera/image/core.clj
+++ b/src/main/clojure/mikera/image/core.clj
@@ -18,11 +18,7 @@
   "Creates a new BufferedImage with the specified width and height.
    Uses ARGB format by default."
   (^BufferedImage [width height]
-    (new-image width height true))
-  (^BufferedImage [width height alpha?]
-    (if alpha?
-      (BufferedImage. (int width) (int height) BufferedImage/TYPE_INT_ARGB)
-      (BufferedImage. (int width) (int height) BufferedImage/TYPE_INT_RGB))))
+    (BufferedImage. (int width) (int height) BufferedImage/TYPE_INT_ARGB)))
 
 (defn resize
   "Resizes an image to the specified width and height. If height is omitted,

--- a/src/test/clojure/mikera/image/test_core.clj
+++ b/src/test/clojure/mikera/image/test_core.clj
@@ -67,13 +67,21 @@
     (set-pixels bi pxs)
     (is (== 0xFFFFFFFF (long-colour (.getRGB bi 0 0))))))
 
+(deftest test-ensure-default-image-type
+  (let [i (ImageIO/read (as-file "src/test/resources/mikera/image/samples/Clojure_300x300.png"))]
+    (is (not= BufferedImage/TYPE_INT_ARGB (.getType i)))
+    (is (= BufferedImage/TYPE_INT_ARGB (.getType (ensure-default-image-type i))))))
+
 (deftest test-load-image
-  (are [r] (instance? BufferedImage (load-image r))
-       "src/test/resources/mikera/image/samples/Clojure_300x300.png"
-       (as-file "src/test/resources/mikera/image/samples/Clojure_300x300.png")
-       (ImageIO/read (as-file "src/test/resources/mikera/image/samples/Clojure_300x300.png"))
-       (resource "mikera/image/samples/Clojure_300x300.png")
-       (input-stream "src/test/resources/mikera/image/samples/Clojure_300x300.png")))
+  (testing "image loading"
+    (are [r] (instance? BufferedImage (load-image r))
+         "src/test/resources/mikera/image/samples/Clojure_300x300.png"
+         (as-file "src/test/resources/mikera/image/samples/Clojure_300x300.png")
+         (ImageIO/read (as-file "src/test/resources/mikera/image/samples/Clojure_300x300.png"))
+         (resource "mikera/image/samples/Clojure_300x300.png")
+         (input-stream "src/test/resources/mikera/image/samples/Clojure_300x300.png")))
+  (testing "load image type conversion"
+    (is (= BufferedImage/TYPE_INT_ARGB (.getType (load-image "src/test/resources/mikera/image/samples/Clojure_300x300.png"))))))
 
 (deftest test-compression
   (testing "png"

--- a/src/test/clojure/mikera/image/test_core.clj
+++ b/src/test/clojure/mikera/image/test_core.clj
@@ -13,9 +13,7 @@
 
 (deftest test-new-image
   (is (instance? BufferedImage (new-image 10 10)))
-  (is (instance? BufferedImage (new-image 10 10 false)))
-  (is (= BufferedImage/TYPE_INT_ARGB (.getType (new-image 10 10))))
-  (is (= BufferedImage/TYPE_INT_RGB (.getType (new-image 10 10 false)))))
+  (is (= BufferedImage/TYPE_INT_ARGB (.getType (new-image 10 10)))))
 
 (deftest test-scale-image
   (let [^BufferedImage bi (new-image 10 10)


### PR DESCRIPTION
Ensure that images loaded by imagez have a consistent pixel format (the current default BufferedImage/TYPE_INT_ARGB). As suggested in #10.
