### PR TITLE
Issue 18: Setting compression type to LZW for GIF images.

### DIFF
--- a/src/main/clojure/mikera/image/core.clj
+++ b/src/main/clojure/mikera/image/core.clj
@@ -164,11 +164,16 @@
 
 (defn- ^javax.imageio.ImageWriteParam apply-compression
   "Applies compression to the write parameter, if possible."
-  [^javax.imageio.ImageWriteParam write-param quality]
-  (when (.canWriteCompressed write-param)
-    (doto write-param
-      (.setCompressionMode ImageWriteParam/MODE_EXPLICIT)
-      (.setCompressionQuality quality)))
+  [^javax.imageio.ImageWriteParam write-param quality ext]
+  (cond (= ext "gif")
+        (doto write-param
+          (.setCompressionMode ImageWriteParam/MODE_EXPLICIT)
+          (.setCompressionType "LZW"))
+
+        (.canWriteCompressed write-param)
+        (doto write-param
+          (.setCompressionMode ImageWriteParam/MODE_EXPLICIT)
+          (.setCompressionQuality quality)))
   write-param)
 
 (defn- ^javax.imageio.ImageWriteParam apply-progressive
@@ -216,7 +221,7 @@
         ^javax.imageio.ImageWriteParam write-param (.getDefaultWriteParam writer)
         iioimage (IIOImage. image nil nil)
         outstream (ImageIO/createImageOutputStream outfile)]
-    (apply-compression write-param quality)
+    (apply-compression write-param quality ext)
     (apply-progressive write-param progressive)
     (doto writer
       (.setOutput outstream)

--- a/src/test/clojure/mikera/image/test_core.clj
+++ b/src/test/clojure/mikera/image/test_core.clj
@@ -89,15 +89,22 @@
           param (.getDefaultWriteParam writer)]
       ;; setting compression quality is not actually supported for PNG, this test
       ;; is just validates that it doesn't crash
-      (is (= param (#'mikera.image.core/apply-compression param 1.0)))))
+      (is (= param (#'mikera.image.core/apply-compression param 1.0 "png")))))
 
   (testing "jpeg"
     (let [^ImageWriter writer (.next (ImageIO/getImageWritersByFormatName "jpeg"))
           param (.getDefaultWriteParam writer)
           compression-fn #'mikera.image.core/apply-compression]
-      (is (= param (#'mikera.image.core/apply-compression param 1.0)))
-      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 1.0)) 1.0))
-      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 0.5)) 0.5)))))
+      (is (= param (#'mikera.image.core/apply-compression param 1.0 "jpeg")))
+      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 1.0 "jpeg")) 1.0))
+      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 0.5 "jpeg")) 0.5))))
+
+  (testing "gif"
+    (let [^ImageWriter writer (.next (ImageIO/getImageWritersByFormatName "gif"))
+          param (.getDefaultWriteParam writer)
+          compression-fn #'mikera.image.core/apply-compression]
+      (is (= param (#'mikera.image.core/apply-compression param 1.0 "gif")))
+      (is (= (.getCompressionType ^ImageWriteParam (compression-fn param 1.0 "gif")) "LZW")))))
 
 (deftest test-progressive
   (let [^ImageWriter writer (.next (ImageIO/getImageWritersByFormatName "jpeg"))

--- a/src/test/clojure/mikera/image/test_io.clj
+++ b/src/test/clojure/mikera/image/test_io.clj
@@ -26,12 +26,19 @@
           param (.getDefaultWriteParam writer)]
       ;; setting compression quality is not actually supported for PNG, this test
       ;; is just validates that it doesn't crash
-      (is (= param (#'mikera.image.core/apply-compression param 1.0)))))
+      (is (= param (#'mikera.image.core/apply-compression param 1.0 "png")))))
 
   (testing "jpeg"
     (let [^ImageWriter writer (.next (ImageIO/getImageWritersByFormatName "jpeg"))
           param (.getDefaultWriteParam writer)
           compression-fn #'mikera.image.core/apply-compression]
-      (is (= param (#'mikera.image.core/apply-compression param 1.0)))
-      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 1.0)) 1.0))
-      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 0.5)) 0.5)))))
+      (is (= param (#'mikera.image.core/apply-compression param 1.0 "jpeg")))
+      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 1.0 "jpeg")) 1.0))
+      (is (= (.getCompressionQuality ^ImageWriteParam (compression-fn param 0.5 "jpeg")) 0.5))
+
+  (testing "gif"
+    (let [^ImageWriter writer (.next (ImageIO/getImageWritersByFormatName "gif"))
+          param (.getDefaultWriteParam writer)
+          compression-fn #'mikera.image.core/apply-compression]
+      (is (= param (#'mikera.image.core/apply-compression param 1.0 "gif")))
+      (is (= (.getCompressionType ^ImageWriteParam (compression-fn param 1.0 "gif")) "LZW")))))))


### PR DESCRIPTION
Based on https://github.com/mikera/imagez/pull/14.
Addresses issue #18.
