### PR TITLE
Better parameter name

### DIFF
--- a/src/main/clojure/mikera/image/colours.clj
+++ b/src/main/clojure/mikera/image/colours.clj
@@ -57,10 +57,10 @@
 
 (defn components-rgb
   "Return the RGB components of a colour value, in a 3-element vector of long values"
-  ([^long argb]
-   [(bit-shift-right (bit-and argb 0x00FF0000) 16)
-    (bit-shift-right (bit-and argb 0x0000FF00) 8)
-    (bit-and argb 0x000000FF)]))
+  ([^long rgb]
+   [(bit-shift-right (bit-and rgb 0x00FF0000) 16)
+    (bit-shift-right (bit-and rgb 0x0000FF00) 8)
+    (bit-and rgb 0x000000FF)]))
 
 (defn rand-colour
   "Returns a random RGB colour value with 100% alpha"


### PR DESCRIPTION
This is a trivial change. My real issue is I want to know what is the opposite function to `components-rgb`? I thought it would be `rgb`, but that does not seem to be the case.
