### PR TITLE
Adds support for Scalr options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [net.mikera/randomz "0.3.0"]
                  [com.jhlabs/filters "2.0.235-1"]]
   
-  :repositories {"clojars.org" "http://clojars.org/repo"}
+  :repositories {"clojars.org" "https://clojars.org/repo"}
   :parent [net.mikera/clojure-pom "0.4.0"]
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure" "src/test/java"]

--- a/src/main/clojure/mikera/image/core.clj
+++ b/src/main/clojure/mikera/image/core.clj
@@ -66,16 +66,33 @@
         nil)
       dst)))
 
+;; Used to define different scalling hints
+;; https://github.com/rkalla/imgscalr/blob/921c26ca273e2d04f36d09e7300e7f21aa165b4b/src/main/java/org/imgscalr/Scalr.java#L356
+(def scale-methods
+  {:automatic     org.imgscalr.Scalr$Method/AUTOMATIC
+   :speed         org.imgscalr.Scalr$Method/SPEED
+   :balanced      org.imgscalr.Scalr$Method/BALANCED
+   :quality       org.imgscalr.Scalr$Method/QUALITY
+   :ultra-quality org.imgscalr.Scalr$Method/ULTRA_QUALITY})
+
+;; Used to define different modes of resizing
+;; https://github.com/rkalla/imgscalr/blob/921c26ca273e2d04f36d09e7300e7f21aa165b4b/src/main/java/org/imgscalr/Scalr.java#L418
+(def scale-modes
+  {:automatic     org.imgscalr.Scalr$Mode/AUTOMATIC
+   :fit-exact     org.imgscalr.Scalr$Mode/FIT_EXACT
+   :fit-to-width  org.imgscalr.Scalr$Mode/FIT_TO_WIDTH
+   :fit-to-height org.imgscalr.Scalr$Mode/FIT_TO_HEIGHT})
+
 (defn resize
   "Resizes an image to the specified width and height. If height is omitted,
    maintains the aspect ratio."
-  (^java.awt.image.BufferedImage [^BufferedImage image new-width new-height]
+  (^java.awt.image.BufferedImage [^BufferedImage image new-width new-height {:keys [method mode]}]
     (Scalr/resize image
-                  org.imgscalr.Scalr$Method/BALANCED
-                  org.imgscalr.Scalr$Mode/FIT_EXACT
+                  (get scale-methods method org.imgscalr.Scalr$Method/BALANCED)
+                  (get scale-modes mode org.imgscalr.Scalr$Mode/FIT_EXACT)
                   (int new-width) (int new-height) nil))
-  (^java.awt.image.BufferedImage [^BufferedImage image new-width]
-    (resize image new-width (/ (* (long new-width) (.getHeight image)) (.getWidth image)))))
+  (^java.awt.image.BufferedImage [^BufferedImage image new-width options]
+    (resize image new-width (/ (* (long new-width) (.getHeight image)) (.getWidth image)) options)))
 
 (defn scale-image
   "DEPRECATED: use 'resize' instead"
@@ -87,10 +104,10 @@
 
 (defn scale
   "Scales an image by a given factor or ratio."
-  (^java.awt.image.BufferedImage [^BufferedImage image factor]
-    (resize image (* (.getWidth image) (double factor)) (* (.getHeight image) (double factor))))
-  (^java.awt.image.BufferedImage [^BufferedImage image width-factor height-factor]
-    (resize image (* (.getWidth image) (double width-factor)) (* (.getHeight image) (double height-factor)))))
+  (^java.awt.image.BufferedImage [^BufferedImage image factor options]
+    (resize image (* (.getWidth image) (double factor)) (* (.getHeight image) (double factor)) options))
+  (^java.awt.image.BufferedImage [^BufferedImage image width-factor height-factor options]
+    (resize image (* (.getWidth image) (double width-factor)) (* (.getHeight image) (double height-factor)) options)))
 
 (defn ensure-default-image-type
   "If the provided image is does not have the default image type
@@ -122,8 +139,10 @@
 
 (defn zoom
   "Zooms into (scales) an image with a given scale factor."
+  (^java.awt.image.BufferedImage [^BufferedImage image factor options]
+    (scale image factor options))
   (^java.awt.image.BufferedImage [^BufferedImage image factor]
-    (scale image factor)))
+    (scale image factor {})))
 
 (defn flip
   "Flips an image in the specified direction :horizontal or :vertical"

--- a/src/test/clojure/mikera/image/demo.clj
+++ b/src/test/clojure/mikera/image/demo.clj
@@ -28,12 +28,15 @@
 	;; demo of visualising a colour gradient
 	(show (gradient-image wheel))
 
-        (save ant "/path/to/new-ant.png" :quality 0.9 :progressive true)
+        #_(save ant "/path/to/new-ant.png" :quality 0.9 :progressive true)
     
   ;; change pixels on an image, using colour components     
   (let [temp (copy ant)]
     (dotimes [x 256]
       (with-components [[r g b] (get-pixel ant x 20)]
         (set-pixel temp x 20 (rgb-from-components b x r))))
-    (show temp))     
+    (show temp))
+
+  ;; resize an image with options
+  (show (resize ant 250 {:method :ultra-quality}))
 )

--- a/src/test/clojure/mikera/image/test_core.clj
+++ b/src/test/clojure/mikera/image/test_core.clj
@@ -30,8 +30,8 @@
   (let [img (copy TEST-IMAGE 2.0)]
     (is (= 4 (width img)))
     (is (= 4 (height img)))
-    (is (= col/green) (get-pixel img 2 2))
-    (is (= col/clear) (get-pixel img 1 1))))
+    (is (= col/green (get-pixel img 2 2)))
+    (is (= col/clear (get-pixel img 1 1)))))
 
 (deftest test-scale-image
   (let [^BufferedImage bi (new-image 10 10)
@@ -57,7 +57,7 @@
 
 (deftest test-scale
   (let [^BufferedImage bi (new-image 10 10)
-        bi (scale bi 2.0 3.0)]
+        bi (scale bi 2.0 3.0 {})]
     (is (instance? BufferedImage bi))
     (is (== 20 (.getWidth bi)))
     (is (== 30 (.getHeight bi)))))


### PR DESCRIPTION
fixes #29 

@mikera let me know if anything jumps out as wrong/improvable :)

Due to the multi-arity signatures of `resize` and `scale` I found it difficult to create a backwards compatible change that made sense. So a couple of options seemed viable to me:

1. Leave as is in the PR and `options` is now required (probably a major version change?)
2. Convert all arguments to entries in an `options` or `params` map - i.e `:new-width`, `:new-height` (probably a major version change?) Something like:

```clojure
(scale img {:height 100 :width: 100 :method :ultra-quaity})
```

3. Something entirely different because I'm fairly certain I don't know everything 😄 

Again, thanks a lot for this lib! Let me know what I can do to help get this PR merged 💯 