### PR TITLE
Move show to gui ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Contains various utility functions for handling colours and bitmap images.
 (def ant (load-image-resource "mikera/image/samples/Ant.png"))
 
 ;; show the iamge, after applying an "invert" filter
-(show (filter-image ant (filt/invert)))
+(require '[mikera.image.gui :as gui])
+(gui/show (filter-image ant (filt/invert)))
 ```
 
 ![Inverted ant](http://clojurefun.files.wordpress.com/2013/05/inverted-ant.png)
@@ -50,6 +51,7 @@ Imagez requires Clojure 1.4 and above.
 ```clojure
 (use 'mikera.image.core)
 (use 'mikera.image.colours)
+(use 'mikera.image.gui)
 
 ;; create a new image
 (def bi (new-image 32 32))

--- a/src/main/clojure/mikera/image/core.clj
+++ b/src/main/clojure/mikera/image/core.clj
@@ -9,8 +9,7 @@
   (:import [java.awt Graphics2D Image Color])
   (:import [java.awt.image BufferedImage BufferedImageOp])
   (:import [javax.imageio ImageIO IIOImage ImageWriter ImageWriteParam])
-  (:import [org.imgscalr Scalr])
-  (:import [mikera.gui Frames]))
+  (:import [org.imgscalr Scalr]))
 
 (set! *unchecked-math* :warn-on-boxed)
 (set! *warn-on-reflection* true)
@@ -235,22 +234,6 @@
       im))
   (^java.awt.image.BufferedImage [spectrum-fn]
     (gradient-image spectrum-fn 200 60)))
-
-(defn show
-  "Displays an image in a new frame.
-
-   The frame includes simple menus for saving an image, and other handy utilities.
-
-   Options can be supplied in keyword arguments as follows:
-     :zoom   - zoom the image by a specified factor, e.g. 2.0. Performs smoothing
-     :resize - resizes the image by either a specified factor or to a given target shape e.g. [256 256]
-     :title  - specifies the title of the resulting frame
-   "
-  ([image & {:keys [zoom resize title]}]
-    (let [^BufferedImage image (if zoom (mikera.image.core/zoom image (double zoom)) image)
-          ^BufferedImage image (if resize (mikera.image.core/copy image resize) image)
-          title (or title "Imagez Frame")]
-      (Frames/display image (str title)))))
 
 (defn- ^javax.imageio.ImageWriteParam apply-compression
   "Applies compression to the write parameter, if possible."

--- a/src/main/clojure/mikera/image/gui.clj
+++ b/src/main/clojure/mikera/image/gui.clj
@@ -1,0 +1,21 @@
+(ns mikera.image.gui
+  "Namespace for showing images in a window"
+  (:require [mikera.image.core :as core])
+  (:import [java.awt.image BufferedImage])
+  (:import [mikera.gui Frames]))
+
+(defn show
+  "Displays an image in a new frame.
+
+   The frame includes simple menus for saving an image, and other handy utilities.
+
+   Options can be supplied in keyword arguments as follows:
+     :zoom   - zoom the image by a specified factor, e.g. 2.0. Performs smoothing
+     :resize - resizes the image by either a specified factor or to a given target shape e.g. [256 256]
+     :title  - specifies the title of the resulting frame
+   "
+  ([image & {:keys [zoom resize title]}]
+    (let [^BufferedImage image (if zoom (core/zoom image (double zoom)) image)
+          ^BufferedImage image (if resize (core/copy image resize) image)
+          title (or title "Imagez Frame")]
+      (Frames/display image (str title)))))

--- a/src/test/clojure/mikera/image/demo.clj
+++ b/src/test/clojure/mikera/image/demo.clj
@@ -4,6 +4,7 @@
   (:use mikera.image.filters)
   (:use mikera.image.spectrum)
   (:use mikera.image.dither)
+  (:use mikera.image.gui)
   (:require [clojure.java.io :refer [resource]]))
 
 ;; load an image from a packaged resouce on the classpath


### PR DESCRIPTION
The ns dependency on `mikera.gui` leads to a dependency on `sun.java2d.opengl.OGLRenderQueue` which spawns a thread during its static creation. This is unneeded overhead for anyone not using the `show` fn and it interferes with native-image compilation with graal. This refactor makes GUI, and thus OpenGL, support opt-in.

**NOTE:** This is a breaking change for anyone currently using the `show` fn. However you handle versioning, this should be taken into consideration. I do think it's an important separation of concerns though.