### PR TITLE
Set compressiontype for .bmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .nrepl-port
 /bin/
 /.externalToolBuilders/
+/.clj-kondo/.cache
+/.lsp/.cache
+/.portal

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["src/main/clojure"]
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        net.mikera/cljunit {:mvn/version "0.6.0"}
+        net.mikera/clojure-utils {:mvn/version "0.8.0"}
+        org.imgscalr/imgscalr-lib {:mvn/version "4.2"}
+        net.mikera/mathz {:mvn/version "0.3.0"}
+        net.mikera/mikera-gui {:mvn/version "0.3.1"}
+        net.mikera/randomz {:mvn/version "0.3.0"}
+        com.jhlabs/filters {:mvn/version "2.0.235-1"}}}

--- a/src/main/clojure/mikera/image/core.clj
+++ b/src/main/clojure/mikera/image/core.clj
@@ -260,6 +260,11 @@
           (.setCompressionMode ImageWriteParam/MODE_EXPLICIT)
           (.setCompressionType "LZW"))
 
+        (= ext "bmp")
+        (doto write-param
+          (.setCompressionMode ImageWriteParam/MODE_EXPLICIT)
+          (.setCompressionType "BI_BITFIELDS"))
+
         (.canWriteCompressed write-param)
         (doto write-param
           (.setCompressionMode ImageWriteParam/MODE_EXPLICIT)


### PR DESCRIPTION
This is similar to #18 -- we got an IllegalStateException when trying to write a `.bmp` file, because no compression type was set for that. We're currently using my fork with this change at work.

I added a `deps.edn` file because I wanted to use my fork as a git dep (and also added some things to `.gitignore` from my VS Code/LSP/clj-kondo setup). Accepting the whole PR would allow folks to use ImageZ as a git dep, if you think that's valuable?

If you want just the `.bmp` compression type change, let me know.