### PR TITLE
Make imagez testable via Clojure CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 /bin/
 /.externalToolBuilders/
 /.clj-kondo/.cache
+/.cpcache
 /.lsp/.cache
 /.portal

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,20 @@
 {:paths ["src/main/clojure"]
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}
-        net.mikera/cljunit {:mvn/version "0.6.0"}
         net.mikera/clojure-utils {:mvn/version "0.8.0"}
         org.imgscalr/imgscalr-lib {:mvn/version "4.2"}
         net.mikera/mathz {:mvn/version "0.3.0"}
         net.mikera/mikera-gui {:mvn/version "0.3.1"}
         net.mikera/randomz {:mvn/version "0.3.0"}
-        com.jhlabs/filters {:mvn/version "2.0.235-1"}}}
+        com.jhlabs/filters {:mvn/version "2.0.235-1"}}
+ :aliases
+ {:test {:extra-paths ["src/test/clojure"
+                       "src/test/resources"]
+         :extra-deps {net.mikera/cljunit {:mvn/version "0.6.0"}
+                      io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts ["-m" "cognitect.test-runner"
+                     "-d" "src/test/clojure"
+                     "-r" ".*\\.test-.*"]
+         :exec-fn cognitect.test-runner.api/test
+         :exec-args {:dirs ["src/test/clojure"]
+                     :patterns [".*\\.test-.*"]}}}}


### PR DESCRIPTION
I didn't expect you to merge the previous PR so quickly -- thank you!

This is a small update to my previous PR that improves the `deps.edn` by moving the `test` scope dependency to a `:test` alias and adding Cognitect's `test-runner` so you can run tests via:

* `clojure -M:test` or
* `clojure -X:test`

Let me know if you want me to add any notes to the README to show usage as a git dep or how to run tests.

If you're interested, I can add a `build.clj` for creating a deployable JAR via the Clojure CLI, in a separate PR?